### PR TITLE
Update syslog type to udp

### DIFF
--- a/lib/streams/syslog.js
+++ b/lib/streams/syslog.js
@@ -12,7 +12,7 @@ module.exports = function(options) {
       host: 'localhost',
       port: 514,
       facility: syslog.facility.local0,
-      type: 'sys'
+      type: 'udp'
     }, options))
   };
 };


### PR DESCRIPTION
Failing to supply the `opts.type` is defaulting to `sys` (aka syslog via system calls) rather than  over UDP network. In practice it makes the host / port not being used (system calls will only go locally, and not over the network) making it extremely confusing - and effectively wrong.

```
new Logger({
  name: name,
  stream: syslog,
  options: {
    host: 1.1.1.1,
    port: 514
  }
})

# This will never go to 1.1.1.1 and instead only be saved locally because of the defaulted type to sys
```

Note - updating the default to UDP will likely be a breaking change for components using this library; it now requires the syslog service (rsyslog, etc.) to be configured to listen on UDP/514. Also, long lines (logs exceeding 1024char) will most certainly be truncated and the configuration will need to be changed to use TCP instead (and further adjustment on the syslog service to also listen on TCP/514)