### PR TITLE
fix:  use bunyan-syslog to support node 12

### DIFF
--- a/lib/streams/syslog.js
+++ b/lib/streams/syslog.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const syslog = require('syslog-bunyan-logger');
+const syslog = require('bunyan-syslog');
 
 module.exports = function(options) {
   if (options == null) {
@@ -11,7 +11,7 @@ module.exports = function(options) {
     stream: syslog.createBunyanStream(Object.assign({
       host: 'localhost',
       port: 514,
-      facility: syslog.facility.local0,
+      facility: syslog.local0,
       type: 'sys'
     }, options))
   };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "bunyan": "^1.8.5",
     "bunyan-debug-stream": "^1.0.7",
-    "file-register": "^0.1.0",
-    "syslog-bunyan-logger": "^1.0.0"
+    "bunyan-syslog": "^0.3.3",
+    "file-register": "^0.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.16",


### PR DESCRIPTION
Issue: #8 

current install this lib with node version 12 is not a success, so changing an out of date dependency system lib to solve this issue.